### PR TITLE
Switch to prod folder in S3

### DIFF
--- a/meters/payments_s3.py
+++ b/meters/payments_s3.py
@@ -104,7 +104,7 @@ def aws_list_files(year, month, client):
     """
     response = client.list_objects(
         Bucket=BUCKET_NAME,
-        Prefix="meters/dev/archipel_transactionspub/" + str(year) + "/" + str(month),
+        Prefix="meters/prod/archipel_transactionspub/" + str(year) + "/" + str(month),
     )
 
     for content in response.get("Contents", []):


### PR DESCRIPTION
Need to make this change as the payment data is not being updated in the `dev` folder in S3 anymore. I have switched over to the `prod` folder for payments. 

PowerBI is showing no recent flowbird data for this reason.