### PR TITLE
Passport data scripts

### DIFF
--- a/meters/passport_DB.py
+++ b/meters/passport_DB.py
@@ -1,0 +1,253 @@
+import os
+import ntpath
+import argparse
+import logging
+from datetime import datetime
+
+from pypgrest import Postgrest
+import pandas as pd
+import boto3
+
+import utils
+
+AWS_ACCESS_ID = os.getenv("AWS_ACCESS_ID")
+AWS_PASS = os.getenv("AWS_PASS")
+BUCKET_NAME = os.getenv("BUCKET_NAME")
+
+POSTGREST_ENDPOINT = os.getenv("POSTGREST_ENDPOINT")
+POSTGREST_TOKEN = os.getenv("POSTGREST_TOKEN")
+
+S3_ENV = "prod"
+
+
+def handle_year_month_args(year, month, lastmonth, s3_client):
+    """
+    Parameters
+    ----------
+    year : Int
+        Argument provided value for year.
+    month : Int
+        Argument provided value for month.
+    lastmonth : Bool
+        Argument that determines if the previous month should also be queried.
+    client : boto3 client object
+        For sending on to get_csv_list
+    Returns
+    -------
+    csv_file_list : List
+        A list of the csv files to be downloaded and upsert to Postgres.
+    """
+    # If args are missing, default to current month and/or year
+    if not year:
+        f_year = datetime.now().year
+    else:
+        f_year = year
+
+    if not month:
+        f_month = datetime.now().month
+    else:
+        f_month = month
+
+    file_list = get_file_list(f_year, f_month, s3_client)
+
+    if not month and not year:
+        if lastmonth == True:
+            prev_month = f_month - 1
+            prev_year = f_year
+            if prev_month == 0:
+                prev_year = prev_year - 1
+                prev_month = 12
+            logger.debug(
+                f"Getting data from folders: {prev_month}-{prev_year} and {f_month}-{f_year}"
+            )
+            prev_list = get_file_list(prev_year, prev_month, s3_client)
+            file_list.extend(prev_list)
+        else:
+            logger.debug(f"Getting data from folders: {f_month}-{f_year}")
+
+    file_list = [f for f in file_list if f.endswith(".json")]
+
+    return file_list
+
+
+def get_file_name(file_key):
+    """
+    Returns the name of an email file based on the full s3 file path
+    :param file_key: the file path
+    :return: string
+    """
+    return ntpath.basename(file_key)
+
+
+def get_file_list(year, month, s3_client):
+    """
+    Returns an array of files parsed into an actual array (as opposed to an object)
+    :return: array of strings
+    """
+    csv_file_list = []
+    pending_csv_list = aws_list_files(year, month, s3_client)
+    for csv_file in pending_csv_list:
+        csv_file_list.append(csv_file)
+
+    # Remove the first item, it is not needed
+    # since it is just the name of the folder
+    csv_file_list.pop(0)
+
+    # Finally return the final list
+    return csv_file_list
+
+
+def aws_list_files(year, month, client):
+    """
+    Returns a list of email files.
+    :return: object
+    """
+    response = client.list_objects(
+        Bucket=BUCKET_NAME, Prefix=f"app/{S3_ENV}/{str(year)}/{str(month)}",
+    )
+
+    for content in response.get("Contents", []):
+        yield content.get("Key")
+
+
+def transform(passport):
+    # Add "passport" to clarify where how the transaction was completed
+    passport["source"] = "Passport - " + passport["Method"]
+
+    passport["payment_method"] = passport["Payment Type"].str.replace(
+        "Credit/Debit Card", "CARD", regex=True
+    )
+
+    # Convert string currency amounts to floats
+    passport["amount"] = (
+        passport["Parking Revenue"].str.replace("$", "", regex=True).astype(float)
+    )
+    passport["net_revenue"] = (
+        passport["Net Revenue"].str.replace("$", "", regex=True).astype(float)
+    )
+
+    passport["start_time"] = pd.to_datetime(
+        passport["Entry Time"],
+        format="%Y/%m/%d %I:%M:%S %p",
+        infer_datetime_format=True,
+    )
+
+    passport["end_time"] = pd.to_datetime(
+        passport["Exit Time"], format="%Y/%m/%d %I:%M:%S %p", infer_datetime_format=True
+    )
+
+    passport["duration_min"] = (
+        (passport["end_time"] - passport["start_time"]).dt.seconds
+    ) / 60
+
+    # Convert back to string for datetime fields
+    passport["start_time"] = passport["start_time"].astype(str)
+    passport["end_time"] = passport["end_time"].astype(str)
+
+    # Renaming columns to match schema
+    passport = passport.rename(
+        columns={
+            "Transaction #": "id",
+            "Zone #": "zone_id",
+            "Zone Group": "zone_group",
+        }
+    )
+
+    # Subset of columns for aligning schema
+    passport = passport[
+        [
+            "id",
+            "zone_id",
+            "zone_group",
+            "payment_method",
+            "start_time",
+            "end_time",
+            "duration_min",
+            "amount",
+            "net_revenue",
+            "source",
+        ]
+    ]
+
+    return passport
+
+
+def to_postgres(df, client):
+    # Upsert to database
+    payload = df.to_dict(orient="records")
+
+    res = client.upsert(resource="passport_transactions_raw", data=payload)
+
+    df = df[
+        [
+            "id",
+            "payment_method",
+            "zone_group",
+            "zone_id",
+            "duration_min",
+            "start_time",
+            "end_time",
+            "amount",
+            "source",
+        ]
+    ]
+
+    payload = df.to_dict(orient="records")
+
+    res = client.upsert(resource="transactions", data=payload)
+
+    return res
+
+
+def main(args):
+    s3_client = boto3.client(
+        "s3", aws_access_key_id=AWS_ACCESS_ID, aws_secret_access_key=AWS_PASS,
+    )
+
+    client = Postgrest(
+        POSTGREST_ENDPOINT,
+        token=POSTGREST_TOKEN,
+        headers={"Prefer": "return=representation"},
+    )
+
+    # Get list of JSON files and handle year/month args
+    file_list = handle_year_month_args(args.year, args.month, args.lastmonth, s3_client)
+
+    # Go through all files and combine into a dataframe
+    data = []
+    for file in file_list:
+        # Parse the file
+        if ".json" in file:
+            response = s3_client.get_object(Bucket=BUCKET_NAME, Key=file)
+            # Read the JSON in each object
+            df = pd.read_json(response.get("Body"))
+            print("Loaded File: '%s'" % file)
+
+            df = transform(df)
+
+            res = to_postgres(df, client)
+
+
+# CLI arguments definition
+parser = argparse.ArgumentParser()
+
+parser.add_argument(
+    "--year", type=int, help=f"Year of folder to select, defaults to current year",
+)
+
+parser.add_argument(
+    "--month", type=int, help=f"Month of folder to select. defaults to current month",
+)
+
+parser.add_argument(
+    "--lastmonth",
+    type=bool,
+    help=f"Will download from current month folder as well as previous.",
+    default=False,
+)
+
+args = parser.parse_args()
+
+logger = utils.get_logger(__file__, level=logging.DEBUG)
+
+main(args)

--- a/meters/passport_DB.py
+++ b/meters/passport_DB.py
@@ -20,7 +20,7 @@ POSTGREST_TOKEN = os.getenv("POSTGREST_TOKEN")
 S3_ENV = "prod"
 
 
-def handle_year_month_args(year, month, lastmonth, s3_client):
+def get_csv_list_for_processing(year, month, lastmonth, s3_client):
     """
     Parameters
     ----------
@@ -211,7 +211,9 @@ def main(args):
     )
 
     # Get list of JSON files and handle year/month args
-    file_list = handle_year_month_args(args.year, args.month, args.lastmonth, s3_client)
+    file_list = get_csv_list_for_processing(
+        args.year, args.month, args.lastmonth, s3_client
+    )
 
     # Go through all files and combine into a dataframe
     data = []

--- a/meters/passport_txns.py
+++ b/meters/passport_txns.py
@@ -127,7 +127,7 @@ def get_todos(start_date, end_date):
 
 
 def remove_forbidden_keys(data):
-    """Remove forbidden keys from datta
+    """Remove forbidden keys from data
 
     Args:
         data (list): A list of dictionaries, one per transactions

--- a/meters/passport_txns.py
+++ b/meters/passport_txns.py
@@ -1,0 +1,244 @@
+"""Fetch Flowbird meter transactions and load to S3"""
+import argparse
+from datetime import datetime, timezone, timedelta
+import json
+import logging
+import os
+
+import boto3
+import requests
+
+import utils
+
+
+# Settings
+ROOT_DIR = "app"
+DATE_FORMAT_API = "%m/%d/%Y"
+DATE_FORMAT_INPUT = "%Y-%m-%d"
+
+# OpsMan Endpoints
+LOGIN_URL = "https://ppprk.com/server/opmgmt/api/index.php/login"
+REPORT_URL = "https://ppprk.com/server/opmgmt/api/reports_index.php/runcustomreport"
+
+# OpsMan Credentials
+USER = os.getenv("OPS_MAN_USER")
+PASSWORD = os.getenv("OPS_MAN_PASS")
+
+# AWS
+AWS_ACCESS_ID = os.getenv("AWS_ACCESS_ID")
+AWS_PASS = os.getenv("AWS_PASS")
+BUCKET = os.getenv("BUCKET_NAME")
+
+
+def validate_session(session):
+
+    try:
+        assert session.cookies.get("omsessiondata")
+        assert session.cookies.get("PHPSESSID")
+    except Exception as e:
+        raise ValueError(f"Session failed validation: {str(e)}")
+    return True
+
+
+def start_session(user, password, url):
+    payload = {
+        "username": user,
+        "password": password,
+        "setsessions": "1",
+    }
+    params = {
+        "timezonename": "Etc%2FGMT-6",
+    }
+    session = requests.Session()
+    res = session.post(url, json=payload, params=params)
+    res.raise_for_status()
+    validate_session(session)
+    return session
+
+
+def get_report_params(session):
+    return {
+        "report_id": 295,
+        "timezonename": "Etc/GMT-6",
+    }
+
+
+def get_report_payload(start_date, start_count, page_size):
+    return {
+        "startdate": start_date.strftime(DATE_FORMAT_API),
+        "enddate": start_date.strftime(DATE_FORMAT_API),
+        "locale": "en",
+        "operator_id": [550],
+        "zone_id": [],
+        "start": start_count,
+        "count": page_size,
+    }
+
+
+def handle_date_args(start_string, end_string):
+    """Parse or set default start and end dates from CLI args.
+
+    Args:
+        start_string (string): Date (in UTC) of earliest records to be fetched (YYYY-MM-DD).
+            Defaults to yesterday.
+        end_string (string): Date (in UTC) of most recent records to be fetched (YYYY-MM-DD).
+            Defaults to today.
+
+    Returns:
+        list: The start date and end date as python datetime objects
+    """
+    if start_string:
+        # parse CLI arg date
+        start_date = datetime.strptime(start_string, DATE_FORMAT_INPUT).replace(
+            tzinfo=timezone.utc
+        )
+    else:
+        # create yesterday's date
+        start_date = datetime.now(timezone.utc) - timedelta(days=1)
+
+    if end_string:
+        # parse CLI arg date
+        end_date = datetime.strptime(end_string, DATE_FORMAT_INPUT).replace(
+            tzinfo=timezone.utc
+        )
+    else:
+        # create today's date
+        end_date = datetime.now(timezone.utc)
+
+    return start_date, end_date
+
+
+def get_todos(start_date, end_date):
+    """Generate a list of dates to be fetched.
+
+    Args:
+        start (datetime.datetime): The earliest day to process
+        end (datetime.datetime): The last day to process
+    Returns:
+      list: a list of flowbird-API-friendly date strings that fall within (and including)
+        the given given start/end
+    """
+    # adjust end date to midnight the next day
+    end_date = end_date + timedelta(days=1)
+    # calculate the # of days between start and end
+    delta = end_date - start_date
+    # generate a list of datetime objs within the the delta
+    return [start_date + timedelta(days=x) for x in range(delta.days)]
+
+
+def remove_forbidden_keys(data):
+    """Remove forbidden keys from datta
+
+    Args:
+        data (list): A list of dictionaries, one per transactions
+
+    Returns:
+        list: A list of dictionariess, one per transaction, with forbidden keys removed
+    """
+
+    # There are different forbidden keys based on the report requested
+    forbidden_keys = ["customer id", "space/lpn"]
+    new_data = []
+    for row in data:
+        new_row = {k: v for k, v in row.items() if k.lower() not in forbidden_keys}
+        new_data.append(new_row)
+    return new_data
+
+
+def format_file_key(file_date, env):
+    """Format an S3 file path
+
+    Args:
+        chunk_start (str): A date string (in flowbird API query format)
+
+    Returns:
+        str: an S3 path + filename, aka the object key, in the format
+          meters/transaction_history/year/month/<query-string>.json
+    """
+    return f"{ROOT_DIR}/{env}/{file_date.year}/{file_date.month}/{file_date.strftime(DATE_FORMAT_INPUT)}.json"
+
+
+def main(args):
+    # Format arguments and get list of dates
+    start_date, end_date = handle_date_args(args.start, args.end)
+    todos = get_todos(start_date, end_date)
+
+    # Log in to OpsMan
+    session = start_session(USER, PASSWORD, LOGIN_URL)
+
+    # AWS log in
+    s3 = boto3.client(
+        "s3", aws_access_key_id=AWS_ACCESS_ID, aws_secret_access_key=AWS_PASS,
+    )
+
+    # Get request params
+    params = get_report_params(session)
+
+    for chunk_start in todos:
+        stop = False
+        start_count = 0
+        page_size = 200
+        records = []
+
+        # Results paginated, so go through each page and download the data
+        while not stop:
+            # get data
+            logger.debug(
+                f"Fetching records for {chunk_start} starting at {start_count}"
+            )
+            payload = get_report_payload(chunk_start, start_count, page_size)
+            res = session.post(REPORT_URL, json=payload, params=params)
+            res.raise_for_status()
+
+            # Handle data
+            data = res.json()
+            current_records = data["data"]
+            records.extend(current_records)
+            total_record_count = data["count"]
+            current_record_count = len(current_records)
+            logger.debug(f"Found: {current_record_count} records")
+            logger.debug(f"{len(records)} out of {total_record_count} downloaded")
+
+            # stop condition and go to next page
+            start_count += page_size
+            stop = len(records) >= total_record_count
+
+        # Drop fields we don't need
+        records = remove_forbidden_keys(records)
+        key = format_file_key(chunk_start, args.env)
+
+        # Send to S3 bucket
+        logger.debug(f"Uploading to s3: {key}")
+        s3.put_object(Body=json.dumps(records), Bucket=BUCKET, Key=key)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--start",
+        type=str,
+        help=f"Date (in UTC) of earliest records to be fetched (YYYY-MM-DD). Defaults to yesterday",
+    )
+
+    parser.add_argument(
+        "--end",
+        type=str,
+        help=f"Date (in UTC) of the most recent records to be fetched (YYYY-MM-DD). Defaults to today",
+    )
+
+    parser.add_argument(
+        "-e", "--env", default="dev", choices=["dev", "prod"], help=f"The environment",
+    )
+
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help=f"Sets logger to DEBUG level",
+    )
+
+    args = parser.parse_args()
+
+    logger = utils.get_logger(
+        __file__, level=logging.DEBUG if args.verbose else logging.INFO,
+    )
+
+    main(args)


### PR DESCRIPTION
`passport_txns.py` Gets data from the Passport OpsMan website and places it in a S3 bucket. This data is mostly parking transactions completed using the mobile app for Austin. 

`passport_DB.py` takes the S3 bucket and pushes it to the parking postgres database. There are two tables we're using: `passport_transactions_raw` which contains only passport data and `transactions` which is the unified parking data representing all sources. 

These scripts support [7601](https://github.com/cityofaustin/atd-data-tech/issues/7601), and will be added to our Prefect flow that is currently just getting Flowbird transactions.