### PR TITLE
Fiserv Dupes Fix

### DIFF
--- a/meters/fiserv_DB.py
+++ b/meters/fiserv_DB.py
@@ -136,7 +136,9 @@ def id_field_creation(invoice_id, batch_number, sequence_number):
     :return: str
     """
 
-    return str(batch_number) + str(sequence_number) + str(invoice_id)
+    ## Old ID included sequence number but this was changing over time in PARD transactions
+    # return str(batch_number) + str(sequence_number) + str(invoice_id)
+    return str(batch_number) + str(invoice_id)
 
 
 def transform(fiserv_df):
@@ -246,10 +248,9 @@ def main(args):
     csv_file_list = handle_year_month_args(
         args.year, args.month, args.lastmonth, aws_s3_client
     )
-    
+
     if len(csv_file_list) == 0:
         logger.debug("No Files found for selected months, nothing happened.")
-
 
     # Access the files from S3 and place them into a dataframe
     for csv_f in csv_file_list:


### PR DESCRIPTION
[8808](https://github.com/cityofaustin/atd-data-tech/issues/8808)

The Fiserv data we get has no unique ID for each transaction so I was making one based on three fields `(Batch ID, sequence number, and invoice ID)`. 

This data comes in emails, one scheduled to come in 24 hrs after the transaction and another one week after. I update the preliminary data based on this week out data.

It turns out, the `sequence number` was changing between these emails and this is only affecting PARD transactions for some unknown reason (account 885). Changing the sequence number causes the database to not update past transactions but create a dupe for every PARD transaction.

I reran this script locally on my machine and found that `sequence number` is not needed for making a unique ID for each transaction so I am dropping that. 

I'll keep the existing flow running in Prefect but this will likely cause me to wipe and redo the `fiserv_reports_raw` table in the parking database.