### PR TITLE
Bug Fix for Dupe Parking Fiserv Entries

### DIFF
--- a/meters/fiserv_DB.py
+++ b/meters/fiserv_DB.py
@@ -210,8 +210,9 @@ def transform(fiserv_df):
         ),
         axis=1,
     )
+
     # Drop dupes, sometimes there are duplicate records emailed
-    # fiserv_df = fiserv_df.drop_duplicates(subset=["invoice_id"], keep="first")
+    fiserv_df = fiserv_df.drop_duplicates(subset=["id"], keep="first")
 
     return fiserv_df
 

--- a/meters/fiserv_DB.py
+++ b/meters/fiserv_DB.py
@@ -234,10 +234,10 @@ def to_postgres(fiserv_df):
 
     # Upsert to postgres DB
     try:
-        client.upsert(resource="fiserv_reports_raw", data=payload)
-    except:
-        logger.debug(client.res.text)
-        raise
+        res = client.upsert(resource="fiserv_reports_raw", data=payload)
+    except Exception as e:
+        logger.error(client.res.text)
+        raise e
 
 
 def main(args):

--- a/meters/match_field_processing.py
+++ b/meters/match_field_processing.py
@@ -155,10 +155,10 @@ def to_postgres(output, pstgrs):
     payload = output.to_dict(orient="records")
 
     try:
-        pstgrs.upsert(resource="fiserv_reports_raw", data=payload)
-    except:
-        logger.debug(pstgrs.res.text)
-        raise
+        res = pstgrs.upsert(resource="fiserv_reports_raw", data=payload)
+    except Exception as e:
+        logger.error(pstgrs.res.text)
+        raise e
 
 
 def main(args):

--- a/meters/passport_DB.py
+++ b/meters/passport_DB.py
@@ -191,8 +191,10 @@ def transform(passport):
 def to_postgres(df, client):
     # Upsert to database
     payload = df.to_dict(orient="records")
-
-    res = client.upsert(resource="passport_transactions_raw", data=payload)
+    try:
+        res = client.upsert(resource="passport_transactions_raw", data=payload)
+    except:
+        logger.debug(client.res.text)
 
     df = df[
         [
@@ -209,8 +211,10 @@ def to_postgres(df, client):
     ]
 
     payload = df.to_dict(orient="records")
-
-    res = client.upsert(resource="transactions", data=payload)
+    try:
+        res = client.upsert(resource="transactions", data=payload)
+    except:
+        logger.debug(client.res.text)
 
     return res
 

--- a/meters/passport_DB.py
+++ b/meters/passport_DB.py
@@ -190,11 +190,13 @@ def transform(passport):
 
 def to_postgres(df, client):
     # Upsert to database
+
     payload = df.to_dict(orient="records")
     try:
         res = client.upsert(resource="passport_transactions_raw", data=payload)
-    except:
-        logger.debug(client.res.text)
+    except Exception as e:
+        logger.error(client.res.text)
+        raise e
 
     df = df[
         [
@@ -213,8 +215,9 @@ def to_postgres(df, client):
     payload = df.to_dict(orient="records")
     try:
         res = client.upsert(resource="transactions", data=payload)
-    except:
-        logger.debug(client.res.text)
+    except Exception as e:
+        logger.error(client.res.text)
+        raise e
 
     return res
 

--- a/meters/payments_s3.py
+++ b/meters/payments_s3.py
@@ -269,9 +269,9 @@ def to_postgres(smartfolio):
     )
     try:
         res = client.upsert(resource="flowbird_payments_raw", data=payload)
-    except:
-        logger.debug(client.res.text)
-        raise
+    except Exception as e:
+        logger.error(client.res.text)
+        raise e
 
 
 def main(args):

--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -271,7 +271,11 @@ def to_postgres(smartfolio):
         headers={"Prefer": "return=representation"},
     )
 
-    res = client.upsert(resource="flowbird_transactions_raw", data=payload)
+    try:
+        res = client.upsert(resource="flowbird_transactions_raw", data=payload)
+    except Exception as e:
+        logger.error(client.res.text)
+        raise e
 
     # Send data to the combined transactions dataset
     smartfolio = smartfolio[
@@ -289,7 +293,11 @@ def to_postgres(smartfolio):
     smartfolio.loc[:, "source"] = "Parking Meters"
     payload = smartfolio.to_dict(orient="records")
 
-    res = client.upsert(resource="transactions", data=payload)
+    try:
+        res = client.upsert(resource="transactions", data=payload)
+    except Exception as e:
+        logger.error(client.res.text)
+        raise e
 
 
 def main(args):


### PR DESCRIPTION
Was getting a duplicate entry in one of our CSVs stored in S3 for our Fiserv data. Not exactly sure why this was the case, but totals still matched up after dropping this entry according to Ashlande's process so treating this dupe entry as a dupe is appropriate. 

Also added some additional logging for Passport data.

Part of: https://github.com/cityofaustin/atd-data-tech/issues/8945