### PR TITLE
Fix to drop duplicate passport IDs

### DIFF
--- a/meters/passport_DB.py
+++ b/meters/passport_DB.py
@@ -169,6 +169,10 @@ def transform(passport):
     # Ignore zones which were created for testing, they all contain AUS in the ID
     passport = passport[~passport["zone_id"].astype("str").str.contains("AUS")]
 
+    # Dropping duplicate transaction IDs, which can happen for some unexplained reason
+    # During testing, these looks like genuine dupes with same date/time/location
+    passport = passport.drop_duplicates(subset=["id"], keep="last")
+
     # Subset of columns for aligning schema
     passport = passport[
         [


### PR DESCRIPTION
Our Prefect flow for parking data was failing every now and again. It was kinda hard to track down what the issue was as it mostly happened on Friday or Saturday nights and Prefect was not logging the full error message for some reason.

I learned today it was failing because of a duplicate transaction ID.

```
2022-08-04 10:45:07,199 ERROR: {"hint":"Ensure that no rows proposed for insertion within the same command have duplicate constrained values.","details":null,"code":"21000","message":"ON CONFLICT DO UPDATE command cannot affect row a second time"}
```

Looking at the offending ID, it looked like it was a genuine dupe, with the same transaction date, time, and location. I guess this was failing intermittently as Passport must drop these dupes periodically.

This change just makes sure we drop the dupe IDs when processing the data and keep the latest one.