### PR TITLE
Pop from Empty Bug fix

### DIFF
--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -94,7 +94,8 @@ def get_csv_list(year, month, client):
 
     # Remove the first item, it is not needed
     # since it is just the name of the folder
-    csv_file_list.pop(0)
+    if csv_file_list:
+        csv_file_list.pop(0)
 
     # Finally return the final list
     return csv_file_list


### PR DESCRIPTION
Got an error on Prefect this morning trying to run `smartfolio_s3.py`. 

```
File "smartfolio_s3.py", line 97, in get_csv_list
   csv_file_list.pop(0)
IndexError: pop from empty list
```

This is because it is looking for a folder under 2022/9 trying to get September's data. This folder doesn't exist yet because we haven't had any parking data downloaded for that month yet so `csv_file_list` is an empty list.

This bug should resolve itself once we get data into that September folder but I've added an if statement to prevent this bug happening on the first of every month.