### PR TITLE
Null to Text Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ dmypy.json
 # Custom
 .DS_Store
 env_file
+meters/.idea/inspectionProfiles/profiles_settings.xml
+meters/.idea/meters.iml
+meters/.idea/misc.xml
+meters/.idea/modules.xml
+meters/.idea/vcs.xml
+meters/.idea/workspace.xml

--- a/meters/match_field_processing.py
+++ b/meters/match_field_processing.py
@@ -1,7 +1,7 @@
 # Standard Library i`ports
 import os
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import logging
 
 # Related third-party imports
@@ -37,8 +37,8 @@ def handle_date_args(start_string, end_string):
             tzinfo=timezone.utc
         )
     else:
-        # if not given set to January 1st, 2022
-        start_date = datetime(2022, 1, 1, 0, 0, 0, 0, timezone.utc)
+        # if not provided, search the last thirty days of data
+        start_date = datetime.now() - timedelta(30)
 
     if end_string:
         # parse CLI arg date

--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -234,7 +234,8 @@ def transform(smartfolio):
         smartfolio["duration_min"].isna(), "timedelta"
     ]
 
-    smartfolio = smartfolio[smartfolio['transaction_type'] == "Parking"]
+    # If duration is still null, it is because it is a pool entry transaction and doesn't have a end time
+    smartfolio = smartfolio[~smartfolio["duration_min"].isna()]
 
     # Only subset of columns needed for schema
     smartfolio = smartfolio[

--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -217,24 +217,7 @@ def transform(smartfolio):
     smartfolio["meter_id"] = smartfolio["meter_id"].astype(int)
     smartfolio["end_time"] = smartfolio["end_time"].replace("NaT", None)
 
-    # This handles the case where the duration field is null.
-    # Replace with the actual duration between start/end times.
-    smartfolio["start_datetime"] = pd.to_datetime(
-        smartfolio["start_time"], format="%Y-%m-%d %H:%M:%S", infer_datetime_format=True
-    )
-    smartfolio["end_datetime"] = pd.to_datetime(
-        smartfolio["end_time"], format="%Y-%m-%d %H:%M:%S", infer_datetime_format=True
-    )
-    smartfolio["timedelta"] = (
-        smartfolio["end_datetime"] - smartfolio["start_datetime"]
-    ).dt.total_seconds()
-
-    smartfolio["timedelta"] = smartfolio["timedelta"] / 60
-    smartfolio.loc[smartfolio["duration_min"].isna(), "duration_min"] = smartfolio.loc[
-        smartfolio["duration_min"].isna(), "timedelta"
-    ]
-
-    # If duration is still null, it is because it is a pool entry transaction and doesn't have a end time
+    # If duration is null, it is because it is a pool entry transaction and doesn't have an end time
     smartfolio = smartfolio[~smartfolio["duration_min"].isna()]
 
     # Only subset of columns needed for schema

--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -234,6 +234,8 @@ def transform(smartfolio):
         smartfolio["duration_min"].isna(), "timedelta"
     ]
 
+    smartfolio = smartfolio[smartfolio['transaction_type'] == "Parking"]
+
     # Only subset of columns needed for schema
     smartfolio = smartfolio[
         [


### PR DESCRIPTION
Error from Prefect:`InvalidJSONError: Out of range float values are not JSON compliant`

I believe the source of this is the inclusion of some pool entry passes in the Smartfolio data. They don't have a `end_time` or a `duration_min` field so these become null and breaks things. Strange part is that these rows have been included for months and only now are causing issues. 

This is only affecting the Parking Transactions dataset which is supposed to be only parking anyway. Potentially we could make a pool pass dataset as well. 

I'll have to go back and remove these rows that were imported from Socrata 👎 

I should also note that this change won't affect Finance's ability to match transactions as that is covered by a separate script. This is only for the parking transactions dataset.


Affecting Kiosk IDs:

81002119
81002120
81002121
81002122
81002123
81002124

