### PR TITLE
Socrata batch upload

### DIFF
--- a/meters/parking_socrata.py
+++ b/meters/parking_socrata.py
@@ -139,7 +139,7 @@ def fiserv(start, end, pstgrs, soda):
 
     response = remove_forbidden_keys(response)
 
-    if len(response) > 10000:
+    if len(response) > 1000:
         batch_upload(soda, FISERV_DATASET, response)
     else:
         soda.upsert(FISERV_DATASET, response)
@@ -169,7 +169,7 @@ def meters(start, end, pstgrs, soda):
 
     response = tzcleanup(response)
 
-    if len(response) > 10000:
+    if len(response) > 1000:
         batch_upload(soda, METERS_DATASET, response)
     else:
         soda.upsert(METERS_DATASET, response)
@@ -202,7 +202,7 @@ def payments(start, end, pstgrs, soda):
 
     response = remove_forbidden_keys(response)
 
-    if len(response) > 10000:
+    if len(response) > 1000:
         batch_upload(soda, PAYMENTS_DATASET, response)
     else:
         soda.upsert(PAYMENTS_DATASET, response)
@@ -233,7 +233,7 @@ def transactions(start, end, pstgrs, soda):
 
     response = tzcleanup(response)
 
-    if len(response) > 10000:
+    if len(response) > 1000:
         batch_upload(soda, TXNS_DATASET, response)
     else:
         soda.upsert(TXNS_DATASET, response)


### PR DESCRIPTION
Socrata upserting timed out once we got behind after some of the bugs over the weekend preventing the script from running. If our batch is longer than 1,000 we'll upsert in 1,000 row batches.

Borrowed some [code](https://github.com/cityofaustin/atd-knack-services/blob/production/services/records_to_agol.py#L170) for batch uploading as suggestion from @chiaberry 