### PR TITLE
Switch Fiserv to use batch date instead

### DIFF
--- a/meters/config/fiserv.py
+++ b/meters/config/fiserv.py
@@ -6,7 +6,7 @@ REQUIRED_FIELDS = [
     "Terminal ID",
     "Batch No.",
     "Batch Sequence ID",
-    "Funded Date",
+    "Batch Date",
     "Record Date",
     "Processed Sales Amount",
     "Transaction Status",

--- a/meters/config/fiserv.py
+++ b/meters/config/fiserv.py
@@ -21,7 +21,7 @@ FIELD_MAPPING = {
     "Terminal ID": "meter_id",
     "Batch No.": "batch_number",
     "Batch Sequence ID": "batch_sequence_number",
-    "Funded Date": "submit_date",  # These look wrong, but this is indeed correct
+    "Batch Date": "submit_date",
     "Record Date": "funded_date",
     "Processed Sales Amount": "amount",
     "Transaction Status": "transaction_status",

--- a/meters/fiserv_email_pub.py
+++ b/meters/fiserv_email_pub.py
@@ -78,10 +78,13 @@ def format_file_name(emailObject):
         + "/"
         + str(emailObject.date.month)
         + "/"
-        + emailObject.attachments[0]["filename"].replace(" ", "-").replace(".zip", ".csv")
+        + emailObject.attachments[0]["filename"]
+        .replace(" ", "-")
+        .replace(".zip", ".csv")
     )
 
     return file_name
+
 
 def decode_file_contents(email_data, fname):
     """
@@ -96,8 +99,9 @@ def decode_file_contents(email_data, fname):
 
     """
     zip_data = BytesIO(base64.b64decode(email_data))
-    with pyzipper.AESZipFile(zip_data, 'r', compression=pyzipper.ZIP_DEFLATED,
-                             encryption=pyzipper.WZ_AES) as extracted_zip:
+    with pyzipper.AESZipFile(
+        zip_data, "r", compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES
+    ) as extracted_zip:
         with extracted_zip.open(fname, pwd=str.encode(ENCRYPTION_KEY)) as csv_file:
             df = pd.read_csv(csv_file)
     return df
@@ -159,7 +163,9 @@ def main():
                 attachment_name = f"{attachment_name}csv"
 
                 # Parse attachment contents
-                df = decode_file_contents(emailObject.attachments[0]["payload"], attachment_name)
+                df = decode_file_contents(
+                    emailObject.attachments[0]["payload"], attachment_name
+                )
 
                 # Uploading CSV to S3
                 df_to_s3(df, s3, file_name)

--- a/meters/requirements.txt
+++ b/meters/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==0.19.*
 pypgrest==0.1.*
 sodapy==2.1.*
 mail-parser==3.15.*
+pyzipper==0.3.*


### PR DESCRIPTION
I've configured the emails we get from Fiserv to send us the "Batch Date" column instead. Based on my testing, it looks like this is the correct column to use to get things to align with the totals expected by Finance.

Fiserv now requires that email attachments are encrypted using a password I've put in 1pass, so I've included the processing for that here.