### PR TITLE
Individual file loading 

### DIFF
--- a/meters/payments_s3.py
+++ b/meters/payments_s3.py
@@ -335,7 +335,7 @@ parser.add_argument(
     "--files",
     nargs="*",  # Accepts zero or more arguments
     type=str,
-    help="A space-separated list of files locations in S3 to upload (optional)"
+    help="A space-separated list of file locations in S3 to upload (optional)"
 )
 
 args = parser.parse_args()

--- a/meters/payments_s3.py
+++ b/meters/payments_s3.py
@@ -274,9 +274,16 @@ def main(args):
         aws_secret_access_key=AWS_PASS,
     )
 
-    csv_file_list = handle_year_month_args(
-        args.year, args.month, args.lastmonth, aws_s3_client, args.user
-    )
+    # handling arguments
+    if args.files:
+        # manual input of files
+        logger.debug(f"Using manual input list of files: {len(args.files)} files to process.")
+        csv_file_list = args.files
+    else:
+        csv_file_list = handle_year_month_args(
+            args.year, args.month, args.lastmonth, aws_s3_client, args.user
+        )
+
     for csv_f in csv_file_list:
         # Parse the file
         response = aws_s3_client.get_object(Bucket=BUCKET_NAME, Key=csv_f)
@@ -322,6 +329,13 @@ parser.add_argument(
     default="atd",
     choices=["pard", "atd"],
     help=f"The user account to use to access data [atd (parking meters), pard (pool passes)]",
+)
+
+parser.add_argument(
+    "--files",
+    nargs="*",  # Accepts zero or more arguments
+    type=str,
+    help="A space-separated list of files locations in S3 to upload (optional)"
 )
 
 args = parser.parse_args()

--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -344,7 +344,7 @@ parser.add_argument(
     "--files",
     nargs="*",  # Accepts zero or more arguments
     type=str,
-    help="A space-separated list of files locations in S3 to upload (optional)"
+    help="A space-separated list of file locations in S3 to upload (optional)"
 )
 
 args = parser.parse_args()

--- a/meters/smartfolio_s3.py
+++ b/meters/smartfolio_s3.py
@@ -299,9 +299,15 @@ def main(args):
         "s3", aws_access_key_id=AWS_ACCESS_ID, aws_secret_access_key=AWS_PASS,
     )
 
-    csv_file_list = handle_year_month_args(
-        args.year, args.month, args.lastmonth, aws_s3_client
-    )
+    # handling arguments
+    if args.files:
+        # manual input of files
+        logger.debug(f"Using manual input list of files: {len(args.files)} files to process.")
+        csv_file_list = args.files
+    else:
+        csv_file_list = handle_year_month_args(
+            args.year, args.month, args.lastmonth, aws_s3_client
+        )
 
     # Go through all files and combine into a dataframe
     for csv_f in csv_file_list:
@@ -332,6 +338,13 @@ parser.add_argument(
     type=bool,
     help=f"Will download from current month folder as well as previous.",
     default=False,
+)
+
+parser.add_argument(
+    "--files",
+    nargs="*",  # Accepts zero or more arguments
+    type=str,
+    help="A space-separated list of files locations in S3 to upload (optional)"
 )
 
 args = parser.parse_args()


### PR DESCRIPTION
Small quality of life improvement for handling parking data issues. 

I had several files I needed to upload to postgres and I didn't want to re-process several months worth of data, just a few of the CSVs.

This will just allow you to ignore the month/year structure of the S3 bucket and just pass the locations of the CSV files you want to upload like this:

```
python meters/payments_to_s3.py --files meters/prod/archipel_transactionspub/2025/1/20250101000000.csv meters/prod/archipel_transactionspub/2025/1/20250102000000.csv
```

or 

```
python meters/smartfolio_to_s3.py --files meters/prod/transaction_history/2025/1/20250101000000.csv meters/prod/transaction_history/2025/1/20250102000000.csv
```